### PR TITLE
replace outdated Hachimi TL repo with rekoiru's new sprite work

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -12,7 +12,7 @@
     {
         "name": "English (Hachimi Beta)",
         "index": "https://raw.githubusercontent.com/Rekoiru/meta/refs/heads/main/index.json",
-        "short_desc": "The original Hachimi translation, with the latest sprite work. Frequent UI updates with more usage of community terms. May lag behind on Uma Stories. Source: Rekoiru, Old UmaTL (tinyurl.com/UmaTLCredits), GameTora. Contributors: KevinVG207, fling"
+        "short_desc": "The original Hachimi translation, with the latest sprite work. Frequent UI updates with more usage of community terms. May lag behind on stories and events. Source: Rekoiru, Old UmaTL (tinyurl.com/UmaTLCredits), GameTora. Contributors: KevinVG207, fling"
     },
     {
         "name": "Skill Data Only (UmaTL)",

--- a/meta.json
+++ b/meta.json
@@ -10,9 +10,9 @@
         "short_desc": "UmaTL, but replaces skill descriptions with a readable version of internal game data. Source: UmaTL (tinyurl.com/UmaTLCredits). Contributors: noccu"
     },
     {
-        "name": "English (Hachimi)",
-        "index": "https://files.leadrdrk.com/hachimi/tl-en.json",
-        "short_desc": "Translates mostly main parts, imported from other projects. Terms might remain more stable. Currently not updated. Source: Old UmaTL (tinyurl.com/UmaTLCredits), GameTora. Contributors: KevinVG207, Rekoiru, fling"
+        "name": "English (Hachimi Beta)",
+        "index": "https://raw.githubusercontent.com/Rekoiru/meta/refs/heads/main/index.json",
+        "short_desc": "The original Hachimi translation, with the latest sprite work. Frequent UI updates with more usage of community terms. May lag behind on Uma Stories. Source: Rekoiru, Old UmaTL (tinyurl.com/UmaTLCredits), GameTora. Contributors: KevinVG207, fling"
     },
     {
         "name": "Skill Data Only (UmaTL)",


### PR DESCRIPTION
per our conversation in the discord yesterday, reko's repository now contains the fixed version of Lead's outdated translations. this PR replaces the outdated hachimi index with reko's, and updates the description to clarify that it will lag behind on text content.