### PR TITLE
Add Filipino language (Global) to list

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -60,6 +60,13 @@
         "region": "Global"
     },
     {
+        "name": "Filipino",
+        "index": "https://codeberg.org/kita/hachimi-fil-glb/raw/branch/main/index.json",
+        "short_desc": "Pagsasaling Filipino para sa UM:PD / Filipino Translations for UM:PD",
+        "language": "fil",
+        "region": "Global"
+    },
+    {
         "name": "English (UmaTL, Mirror)",
         "index": "https://files.leadrdrk.com/hachimi/umatl.json",
         "short_desc": "Use if you get ZIP errors, see matching desc above. Might be temporary, so keep up to date with developments!",
@@ -76,12 +83,5 @@
         "index": "https://files.leadrdrk.com/hachimi/umatl-sd-only.json",
         "short_desc": "Use if you get ZIP errors, see matching desc above. Might be temporary, so keep up to date with developments!",
         "language": "en"
-    },
-    {
-        "name": "Filipino",
-        "index": "https://codeberg.org/kita/hachimi-fil-glb/raw/branch/main/index.json",
-        "short_desc": "Pagsasaling Filipino para sa UM:PD / Filipino Translations for UM:PD",
-        "language": "fil",
-        "region": "Global"
     }
 ]

--- a/meta.json
+++ b/meta.json
@@ -78,10 +78,10 @@
         "language": "en"
     },
     {
-        "name": "Wikang Filipino",
-	"index": "https://codeberg.org/kita/hachimi-fil-glb/raw/branch/main/index.json",
-	"short_desc": "Pagsasaling Filipino para sa UMPD. By Vyxie",
-	"language": "fil",
-	"region": "Global"
+        "name": "Filipino",
+        "index": "https://codeberg.org/kita/hachimi-fil-glb/raw/branch/main/index.json",
+        "short_desc": "Pagsasaling Filipino para sa UM:PD / Filipino Translations for UM:PD",
+        "language": "fil",
+        "region": "Global"
     }
 ]

--- a/meta.json
+++ b/meta.json
@@ -76,5 +76,12 @@
         "index": "https://files.leadrdrk.com/hachimi/umatl-sd-only.json",
         "short_desc": "Use if you get ZIP errors, see matching desc above. Might be temporary, so keep up to date with developments!",
         "language": "en"
+    },
+    {
+        "name": "Wikang Filipino",
+	"index": "https://codeberg.org/kita/hachimi-fil-glb/raw/branch/main/index.json",
+	"short_desc": "Pagsasaling Filipino para sa UMPD. By Vyxie",
+	"language": "fil",
+	"region": "Global"
     }
 ]


### PR DESCRIPTION
I'm just a passionate honse game fan wanting to add the funny language (a.k.a. Filipino) to the global version. So far, some good progress has been made. Files are hosted primarily on [Codeberg](https://codeberg.org/kita/hachimi-fil-glb) but also available as a mirror on my [GitHub](https://github.com/searinminecraft/hachimi-fil-glb)